### PR TITLE
Fix minor English grammar issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ async function connect() {
   try {
     const firmwareFile = await webdfu.read();
 
-    console.log("Readed: ", firmwareFile);
+    console.log("Read: ", firmwareFile);
   } catch (error) {
     console.error(error);
   }
@@ -62,7 +62,7 @@ async function connect() {
     const firmwareFile = new ArrayBuffer("");
     await webdfu.write(1024, firmwareFile);
 
-    console.log("Writed!");
+    console.log("Written!");
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
**This PR does not affect functionality.**

This is just a very minor (and pedantic) fix in README.md; `s/Readed/Read/` and `s/Writed/Written/` in some example code. I submit this fix without any claim to copyright; the copyright of these changes belongs to Flipper Devices Inc. for any purpose (this is barely worth a PR so if you commit outside of this without credit to me that's completely fine - it was just bothering me a little).